### PR TITLE
escaping braces in regex for 5.16 compliance

### DIFF
--- a/lib/Dist/Zilla/Plugin/AutoMetaResources.pm
+++ b/lib/Dist/Zilla/Plugin/AutoMetaResources.pm
@@ -173,7 +173,7 @@ Name of the distribution (lowercase)
 
 sub _subs(@) {
     my ($format, $vars) = @_;
-    $format =~ s/%{([\w_\.]+)}/$vars->{$1} || ''/ge;
+    $format =~ s/%\{([\w_\.]+)\}/$vars->{$1} || ''/ge;
     return $format;
 }
 


### PR DESCRIPTION
Unescaped left brace in regex is deprecated in perl 5.16. This triggers a compile time warning which, of course, makes the Test::NoWarnings fail. As a result, you can't install Dist::Zilla::Plugin::AutoMetaResources on modern perls.

This patch fixes this =)
